### PR TITLE
MINTEMP, Slightly lower temperature before triggering sensor fault.

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -316,10 +316,10 @@
 // The minimal temperature defines the temperature below which the heater will not be enabled It is used
 // to check that the wiring to the thermistor is not broken.
 // Otherwise this would lead to the heater being powered on all the time.
-#define HEATER_0_MINTEMP 5
-#define HEATER_1_MINTEMP 5
-#define HEATER_2_MINTEMP 5
-#define BED_MINTEMP 5
+#define HEATER_0_MINTEMP 1
+#define HEATER_1_MINTEMP 1
+#define HEATER_2_MINTEMP 1
+#define BED_MINTEMP 1
 
 //To clean the extruder's the best temperature configuration
 #define	PLA_LOAD_TEMP			215


### PR DESCRIPTION
In Scotland it gets cold.
At startup in Winter, the temps were reading 3-4 degrees, so triggering a sensor missing fault.  Until warmed up with a hairdryer !
I'm not sure if zero, or negative value is acceptable so I've changed MINTEMP from 5 to 1.
If zero is OK then I'd go for that.